### PR TITLE
Add Slashtags to SLIP-0044

### DIFF
--- a/slip-0044.md
+++ b/slip-0044.md
@@ -1214,6 +1214,7 @@ Coin type | Path component (`coin_type'`) | Symbol | Coin
 100500 | 0x80018894 | HOME   | [HomeCoin](https://homecoin.ru)
 101010 | 0x80018a92 | STC     | [Starcoin](https://starcoin.org)
 105105 | 0x80019a91 | STRAX  | [Strax](http://www.stratisplatform.com)
+123456 | 0x8001e240 |        | [Slashtags](https://github.com/synonymdev/slashtags)
 200625 | 0x80030fb1 | AKA    | [Akroma](https://akroma.io)
 200665 | 0x80011000 | GENOM  | [GENOM](https://genom.tech)
 246529 | 0x8003c301 | ATS    | [ARTIS sigma1](https://artis.eco)


### PR DESCRIPTION
Slashtags keyPair derivation is described at https://github.com/synonymdev/slashtags/tree/master/specs/slashtags-key-derivation.md